### PR TITLE
Смена private на protected

### DIFF
--- a/controllers/ApiController.php
+++ b/controllers/ApiController.php
@@ -46,7 +46,7 @@ class ApiController extends Controller
     const EVENT_AFTER_FINISH_UPLOAD_FILE = 'afterFinishUploadFile';
     const EVENT_AFTER_EXPORT_ORDERS = 'afterExportOrders';
 
-    private $_ids;
+    protected $_ids;
 
     public function init()
     {


### PR DESCRIPTION
Сделано с целью возможности обращения к обработанным товарам/офферам 
при переопределении через controllerMap обработчика импорта